### PR TITLE
Markdown headlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.settings
 /.classpath
+.idea
+/marklet.iml

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Marklet** is a custom Java Doclet which aims to generate a Javadoc in a markdown format which is ready to use in GitHub. You can check a **Marklet** generated javadoc on the following project :
 
-* [Marklet itself !](https://github.com/Faylixe/marklet/tree/master/javadoc/fr/faylixe/marklet)
+* [Marklet itself!](https://github.com/Faylixe/marklet/tree/master/javadoc/fr/faylixe/marklet)
 * [Google Code Jam API](https://github.com/Faylixe/googlecodejam-client/tree/master/javadoc/fr/faylixe/googlecodejam/client)
 
 In order to use it with Maven, adds the following configuration for the ``maven-javadoc-plugin``

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ in your project ``POM`` :
 
 This will generate the javadoc report into the project directory under subfolder ``javadoc/``.
 
+## Developing Marklet
+
+Marklet requires Apache Maven. In order to build, run
+```
+$ mvn install
+
+```
+
+In order to generate Markdown documentation for Marklet itself, run
+
+```
+$ mvn -P marklet-generation javadoc:javadoc
+```
+
+## License
+
+Marklet is licensed under the Apache License, Version 2.0
+
 ## Current issues
 
 The current version is a pre release with the following feature missing :

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in your project ``POM`` :
 
 This will generate the javadoc report into the project directory under subfolder ``javadoc/``.
 
-##Current issues
+## Current issues
 
 The current version is a pre release with the following feature missing :
 

--- a/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
@@ -86,7 +86,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	 * from the current class. Such hierarchy consists in the
 	 * class inheritance path.
 	 */
-	private void classHierachy() {
+	private void classHierarchy() {
 		final List<ClassDoc> hierarchy = new ArrayList<ClassDoc>();
 		ClassDoc current = classDoc;
 		while (current != null) {
@@ -107,7 +107,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	 * from the current class. Such hiearchy consists in all
 	 * implemented interface.
 	 */
-	private void interfaceHierachy() {
+	private void interfaceHierarchy() {
 		final Set<Type> implementedInterfaces = new HashSet<Type>();
 		ClassDoc current = classDoc;
 		while (current != null) {
@@ -172,10 +172,10 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 		link(packageName, MarkletConstant.README);
 		breakingReturn();
 		newLine();
-		classHierachy();
+		classHierarchy();
 		newLine();
 		newLine();
-		interfaceHierachy();
+		interfaceHierarchy();
 		newLine();
 		newLine();
 		description(classDoc);

--- a/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
@@ -171,6 +171,7 @@ public class MarkdownDocumentBuilder {
 		for (int i = 0; i < level; i++) {
 			buffer.append('#');
 		}
+		buffer.append(' ');
 	}
 
 	/**


### PR DESCRIPTION
GitHub markdown requires a space after the last `#`. This pull request is adding this space, together with a small fix for a typo in the method names