### PR TITLE
Adjust Markdown output, so it works well with Slate

### DIFF
--- a/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
@@ -172,7 +172,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 		item();
 		text(MarkletConstant.PACKAGE);
 		character(' ');
-		link(packageName, MarkletConstant.README);
+		link(packageName, MarkletConstant.README_LINK);
 		newLine();
 		item();
 		classHierarchy();
@@ -180,6 +180,8 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 		newLine();
 		newLine();
 		description(classDoc);
+		newLine();
+		newLine();
 	}
 
 	/**

--- a/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/ClassPageBuilder.java
@@ -93,7 +93,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 			hierarchy.add(current);
 			current = current.superclass();
 		}
-		quote();
+
 		for (int i = hierarchy.size() - 1; i >= 0; i--) {
 			classLink(getSource(), hierarchy.get(i));
 			if (i > 0) {
@@ -117,7 +117,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 		if (!implementedInterfaces.isEmpty()) {
 			text(MarkletConstant.INTERFACE_HIEARCHY_HEADER);
 			newLine();
-			quote();
+			item();
 			final int limit = implementedInterfaces.size() - 1;
 			final Type [] types = implementedInterfaces.toArray(new Type[implementedInterfaces.size()]);
 			for (int i = 0; i < types.length; i++) {
@@ -165,22 +165,21 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	private void header() {
 		title();
 		newLine();
+		newLine();
+
 		final PackageDoc packageDoc = classDoc.containingPackage();
 		final String packageName = packageDoc.name();
+		item();
 		text(MarkletConstant.PACKAGE);
 		character(' ');
 		link(packageName, MarkletConstant.README);
-		breakingReturn();
 		newLine();
+		item();
 		classHierarchy();
-		newLine();
-		newLine();
 		interfaceHierarchy();
 		newLine();
 		newLine();
 		description(classDoc);
-		newLine();
-		newLine();
 	}
 
 	/**
@@ -284,7 +283,6 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 			fieldsSummary();
 			constructorsSummary();
 			methodsSummary();
-			horizontalRule();
 			newLine();
 		}
 	}
@@ -296,7 +294,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	private void constructors() {
 		if (hasConstructor()) {
 			newLine();
-			header(2);
+			header(1);
 			text(MarkletConstant.CONSTRUCTORS);
 			newLine();
 			getOrderedElements(classDoc::constructors).forEach(this::member);
@@ -310,7 +308,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	private void fields() {
 		if (hasField()) {
 			newLine();
-			header(2);
+			header(1);
 			text(MarkletConstant.FIELDS);
 			newLine();
 			getOrderedElements(classDoc::fields)
@@ -329,7 +327,7 @@ public final class ClassPageBuilder extends MarkletDocumentBuilder {
 	private void methods() {
 		if (hasMethod()) {
 			newLine();
-			header(2);
+			header(1);
 			text(MarkletConstant.METHODS);
 			newLine();
 			getOrderedElements(classDoc::methods)

--- a/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
@@ -10,8 +10,11 @@ package fr.faylixe.marklet;
  */
 public class MarkdownDocumentBuilder {
 
-	/** Extension used for markdown file. **/
-	public static final String FILE_EXTENSION = ".md";
+	/** Extension used for linked file. **/
+	public static final String LINK_EXTENSION = ".html";
+
+	/** Extension used for generated markdown file. **/
+	public static final String FILE_EXTENSION = ".html.md";
 
 	/** Bold text decoration. **/
 	private static final String BOLD = "**";

--- a/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/MarkdownDocumentBuilder.java
@@ -16,6 +16,9 @@ public class MarkdownDocumentBuilder {
 	/** Bold text decoration. **/
 	private static final String BOLD = "**";
 
+	/** Inline code snippets **/
+	private static final String CODE = "`";
+
 	/** Italic text decoration. **/
 	private static final String ITALIC = "*";
 
@@ -114,6 +117,17 @@ public class MarkdownDocumentBuilder {
 			.append(BOLD)
 			.append(text)
 			.append(BOLD);
+	}
+
+	/** Apppends this given `text` to the current document with a
+	 * code decoration.
+	 * @param text code snippet to add to the document
+	 */
+	public final void code(final String text) {
+		buffer
+			.append(CODE)
+			.append(text)
+			.append(CODE);
 	}
 	
 	/**

--- a/src/main/java/fr/faylixe/marklet/MarkletConstant.java
+++ b/src/main/java/fr/faylixe/marklet/MarkletConstant.java
@@ -45,7 +45,10 @@ public final class MarkletConstant {
 	public static final String FIELDS = "Fields";
 
 	/** Package index filename. **/
-	public static final String README = "README.md";
+	public static final String README_LINK = "README.html";
+
+	/** Package index filename. **/
+	public static final String README_FILE = "README.html.md";
 
 	/** Label for name. **/
 	public static final String NAME = "Name";

--- a/src/main/java/fr/faylixe/marklet/MarkletDocumentBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/MarkletDocumentBuilder.java
@@ -83,7 +83,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 			urlBuilder
 				.append(path)
 				.append(target.simpleTypeName())
-				.append(MarkdownDocumentBuilder.FILE_EXTENSION);
+				.append(MarkdownDocumentBuilder.LINK_EXTENSION);
 			link(target.simpleTypeName(), urlBuilder.toString());
 		}
 		else {

--- a/src/main/java/fr/faylixe/marklet/MarkletDocumentBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/MarkletDocumentBuilder.java
@@ -43,7 +43,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	private static final String UP_DIRECTORY = "../";
 
 	/** Separator used between parameter name and description. **/
-	private static final String PARAMETER_DETAIL_SEPARATOR = " : ";
+	private static final String PARAMETER_DETAIL_SEPARATOR = ": ";
 
 	/** Target source package from which document will be written. **/
 	private final PackageDoc source;
@@ -106,7 +106,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 */
 	public void typeLink(final PackageDoc source, final Type type) {
 		if (type.isPrimitive()) {
-			bold(type.simpleTypeName());
+			code(type.simpleTypeName());
 		}
 		else {
 			final ClassDoc classDoc = type.asClassDoc();
@@ -228,7 +228,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 * @param element Member to build return label for.
 	 */
 	public void returnSignature(final ProgramElementDoc element) {
-		bold(element.modifiers());
+		code(element.modifiers());
 		if (element.isMethod()) {
 			final MethodDoc method = (MethodDoc) element;
 			character(' ');
@@ -294,7 +294,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 * @param member Member to write signature from.
 	 */
 	private void headerSignature(final ExecutableMemberDoc member) {
-		header(4);
+		header(2);
 		text(member.name());
 		text(member.flatSignature());
 	}
@@ -348,20 +348,17 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 * @param fieldDoc Field documentation to append.
 	 */
 	public void field(final FieldDoc fieldDoc) {
-		header(4);
+		header(2);
 		text(fieldDoc.name());
 		newLine();
-		quote();
-		bold(fieldDoc.modifiers());
+		code(fieldDoc.modifiers());
 		character(' ');
 		typeLink(source, fieldDoc.type());
 		newLine();
 		newLine();
-		quote();
 		description(fieldDoc);
 		newLine();
 		newLine();
-		horizontalRule();
 		newLine();
 	}
 
@@ -380,7 +377,6 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	public void member(final ExecutableMemberDoc member) {
 		headerSignature(member);
 		newLine();
-		quote();
 		description(member);
 		newLine();
 		newLine();
@@ -391,7 +387,6 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 		}
 		exceptions(member.throwsTags());
 		newLine();
-		horizontalRule();
 		newLine();
 	}
 
@@ -406,13 +401,13 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 */
 	private void parameters(final ParamTag[] parameters) {
 		if (parameters.length > 0) {
-			quote();
+			header(3);
 			bold(MarkletConstant.PARAMETERS);
 			newLine();
 			for (final ParamTag parameter : parameters) {
 				item();
 				// TODO : Think about including parameter Type here.
-				text(parameter.parameterName());
+				code(parameter.parameterName());
 				text(PARAMETER_DETAIL_SEPARATOR);
 				description(parameter.inlineTags());
 				//text(parameter.parameterComment()); // TODO : Convert to Doc / for linked tag ? 
@@ -433,10 +428,9 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 */
 	private void returnType(final Tag[] tag) {
 		if (tag.length > 0) {
-			quote();
+			header(3);
 			bold(MarkletConstant.RETURNS);
 			newLine();
-			item();
 			// text(tag[0].text());
 			description(tag[0].inlineTags());
 			newLine();
@@ -452,7 +446,7 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 */
 	private void exceptions(final ThrowsTag[] exceptions) {
 		if (exceptions.length > 0) {
-			quote();
+			header(3);
 			bold(MarkletConstant.THROWS);
 			newLine();
 			for (final ThrowsTag exception : exceptions) {
@@ -476,7 +470,6 @@ public class MarkletDocumentBuilder extends MarkdownDocumentBuilder {
 	 * @throws IOException If any error occurs while closing document.
 	 */
 	public void build(final Path path) throws IOException {
-		horizontalRule();
 		newLine();
 		text(MarkletConstant.BADGE);
 		final String content = super.build();

--- a/src/main/java/fr/faylixe/marklet/MarkletOptions.java
+++ b/src/main/java/fr/faylixe/marklet/MarkletOptions.java
@@ -6,7 +6,15 @@ import com.sun.javadoc.DocErrorReporter;
  * Class that reads and stores provided options
  * for javadoc execution. Options that we care about are :
  * 
- * * Output directory
+ * * `-d` specifies the output directory (default: `javadocs`)
+ * * `-e` specifies the file ending for files to be created (default `md`)
+ * * `-l` specifies the file ending used in internal links (default `md`)
+ *
+ * > The default options are ideal if you want to serve the documentation using GitHub's
+ * > built-in README rendering. If you are using a tool like Slate, change the options as follows:
+ * ```
+ * $ javadoc -doclet fr.faylixe.marklet.Marklet -e html.md -l html …
+ * ```
  * 
  * @author fv
  */
@@ -18,15 +26,33 @@ public final class MarkletOptions {
 	/** Option name for the target output directory. **/
 	private static final String OUTPUT_DIRECTORY_OPTION = "-d";
 
+	/** Default output file ending (`md`) **/
+	private static final String DEFAULT_FILE_ENDING = "md";
+
+	/** Option name for the file ending (`-e`) **/
+	private static final String FILE_ENDING_OPTION = "-e";
+
+	/** Default ending for internal links (`md`). **/
+	private static final String DEFAULT_LINK_ENDING = "md";
+
+	/** Option name for the link ending (`-l`) **/
+	private static final String LINK_ENDING_OPTION = "-l";
+
 	/** Output directory file are generated in. **/
 	private String outputDirectory;
 
+	private String fileEnding;
+
+	private String linkEnding;
+
 	/**
 	 * Default constructor.
-	 * Sets options with their default parameters if availaible.
+	 * Sets options with their default parameters if available.
 	 */
 	private MarkletOptions() {
 		this.outputDirectory = DEFAULT_OUTPUT_DIRECTORY;
+		this.fileEnding = DEFAULT_FILE_ENDING;
+		this.linkEnding = DEFAULT_LINK_ENDING;
 	}
 
 	/**
@@ -86,9 +112,30 @@ public final class MarkletOptions {
 			if (name.equals(OUTPUT_DIRECTORY_OPTION)) {
 				System.out.println("Matching output directory : " + option[1]);
 				options.setOutputDirectory(option[1]);
+			} else if (name.equals(LINK_ENDING_OPTION)) {
+				System.out.println("Matching link ending : " + option[1]);
+				options.setLinkEnding(option[1]);
+			} else if (name.equals(FILE_ENDING_OPTION)) {
+				System.out.println("Matching file ending : " + option[1]);
+				options.setFileEnding(option[1]);
 			}
 		}
 		return options;
 	}
 
+	public String getFileEnding() {
+		return fileEnding;
+	}
+
+	public void setFileEnding(String fileEnding) {
+		this.fileEnding = fileEnding;
+	}
+
+	public String getLinkEnding() {
+		return linkEnding;
+	}
+
+	public void setLinkEnding(String linkEnding) {
+		this.linkEnding = linkEnding;
+	}
 }

--- a/src/main/java/fr/faylixe/marklet/PackagePageBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/PackagePageBuilder.java
@@ -116,7 +116,7 @@ public final class PackagePageBuilder extends MarkletDocumentBuilder {
 		final PackagePageBuilder packageBuilder = new PackagePageBuilder( packageDoc);
 		packageBuilder.header();
 		packageBuilder.indexes();
-		final Path path = directoryPath.resolve(MarkletConstant.README);
+		final Path path = directoryPath.resolve(MarkletConstant.README_FILE);
 		packageBuilder.build(path);
 	}
 

--- a/src/main/java/fr/faylixe/marklet/PackagePageBuilder.java
+++ b/src/main/java/fr/faylixe/marklet/PackagePageBuilder.java
@@ -66,7 +66,7 @@ public final class PackagePageBuilder extends MarkletDocumentBuilder {
 			header(2);
 			text(label);
 			newLine();
-			tableHeader(MarkletConstant.NAME);
+			tableHeader(MarkletConstant.NAME, "Description");
 			Arrays
 				.stream(classDocs)
 				.forEach(this::classRow);
@@ -83,6 +83,8 @@ public final class PackagePageBuilder extends MarkletDocumentBuilder {
 	private void classRow(final ClassDoc classDoc) {
 		startTableRow();
 		classLink(packageDoc, classDoc);
+		cell();
+		text(classDoc.commentText().replaceAll("\\n"," ").replaceFirst("\\..*","."));
 		endTableRow();
 		newLine();
 	}


### PR DESCRIPTION
[lord/slate](https://github.com/lord/slate) is one of the more popular static site generators for Markdown that is optimized for API documentation. I have adjusted the Markdown output in following ways:
- use `code` formatting instead of **bold** for most keywords and primitive types
- remove block quote output, because slate reserves this for examples
- move all headlines one or two levels up, as slate generates a TOC from H1 and H2
- corrected line breaks after headlines and lists
- removed lots of horizontal rules, as they can be styled better with CSS
- changed spacing around punctuation from French style (spaces before and after) to English style (only space after)
- added ability to use `.html` in links and `.html.md` for generated output (I'm planning to make this configurable)
- include short description of the class in package listing.